### PR TITLE
Feat/improve algorithm for too large

### DIFF
--- a/src/lib/clothing/clothing.ts
+++ b/src/lib/clothing/clothing.ts
@@ -40,6 +40,10 @@ export type HumanGender = 'M' | 'W';
 export type ClothingMeasurementImportance = {
 	measurement: HumanMeasurement;
 	allowTolerance: boolean;
+	factors?: {
+		tooHigh: number;
+		tooLow: number;
+	}
 };
 
 export type ClothingName =

--- a/src/lib/clothing/clothingConstants.ts
+++ b/src/lib/clothing/clothingConstants.ts
@@ -3,51 +3,51 @@ import type { HumanGender, ClothingType, ClothingMeasurementImportance, Clothing
 export const clothingMeasurementImportance: { [K in HumanGender]: { [M in ClothingType]: ClothingMeasurementImportance[] } } = {
     'W': {
         'Jacket': [
-            { measurement: 'chestCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
-            { measurement: 'hipCircumference', allowTolerance: true }
+            { measurement: 'hipCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} }
         ],
         'Suit': [
-            { measurement: 'chestCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
-            { measurement: 'hipCircumference', allowTolerance: true }
+            { measurement: 'hipCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} }
         ],
         'Trousers': [
-            { measurement: 'waistCircumference', allowTolerance: false },
+            { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
-            { measurement: 'hipCircumference', allowTolerance: true },
+            { measurement: 'hipCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'insideLegLength', allowTolerance: true }
         ],
         'Skirt': [
-            { measurement: 'waistCircumference', allowTolerance: false },
+            { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
-            { measurement: 'hipCircumference', allowTolerance: true }
+            { measurement: 'hipCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} }
         ],
         'Sweater': [
-            { measurement: 'chestCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true }
         ]
     },
 
     'M': {
         'Jacket': [
-            { measurement: 'chestCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
-            { measurement: 'waistCircumference', allowTolerance: true }
+            { measurement: 'waistCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} }
         ],
         'Suit': [
-            { measurement: 'chestCircumference', allowTolerance: false },
-            { measurement: 'waistCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
+            { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
             { measurement: 'insideLegLength', allowTolerance: true }
         ],
         'Trousers': [
-            { measurement: 'waistCircumference', allowTolerance: false },
+            { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true },
             { measurement: 'insideLegLength', allowTolerance: true }
         ],
         'Sweater': [
-            { measurement: 'chestCircumference', allowTolerance: false },
+            { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
             { measurement: 'height', allowTolerance: true }
         ],
         'Skirt': []

--- a/src/lib/clothing/clothingConstants.ts
+++ b/src/lib/clothing/clothingConstants.ts
@@ -14,9 +14,9 @@ export const clothingMeasurementImportance: { [K in HumanGender]: { [M in Clothi
         ],
         'Trousers': [
             { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
-            { measurement: 'height', allowTolerance: true },
+            { measurement: 'height', allowTolerance: true, factors: {tooHigh: 3, tooLow: 1} },
             { measurement: 'hipCircumference', allowTolerance: true, factors: {tooHigh: 10, tooLow: 1} },
-            { measurement: 'insideLegLength', allowTolerance: true }
+            { measurement: 'insideLegLength', allowTolerance: true, factors: {tooHigh: 3, tooLow: 1}}
         ],
         'Skirt': [
             { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
@@ -43,8 +43,8 @@ export const clothingMeasurementImportance: { [K in HumanGender]: { [M in Clothi
         ],
         'Trousers': [
             { measurement: 'waistCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },
-            { measurement: 'height', allowTolerance: true },
-            { measurement: 'insideLegLength', allowTolerance: true }
+            { measurement: 'height', allowTolerance: true, factors: {tooHigh: 3, tooLow: 1}  },
+            { measurement: 'insideLegLength', allowTolerance: true, factors: {tooHigh: 3, tooLow: 1} }
         ],
         'Sweater': [
             { measurement: 'chestCircumference', allowTolerance: false, factors: {tooHigh: 10, tooLow: 1} },

--- a/src/lib/clothing/clothingUtils.test.ts
+++ b/src/lib/clothing/clothingUtils.test.ts
@@ -11,9 +11,10 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns 0 when measurement is within range', () => {
 		const measurement = 184;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 		const allowTolerance = { up: 0.02, down: 0.02 };
 
-		const res = measurementMetric(measurement, size, allowTolerance);
+		const res = measurementMetric(measurement, size, factors, allowTolerance);
 
 		expect(res).toBe(0);
 	});
@@ -21,9 +22,11 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns negative number when measurement is below range', () => {
 		const measurement = 170;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 		const allowTolerance = { up: 0.02, down: 0.02 };
 
-		const res = measurementMetric(measurement, size, allowTolerance);
+
+		const res = measurementMetric(measurement, size, factors, allowTolerance);
 
 		expect(res).toBeGreaterThan(0);
 	});
@@ -31,9 +34,10 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns positive number when measurement is above range', () => {
 		const measurement = 190;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 		const allowTolerance = { up: 0.02, down: 0.02 };
 
-		const res = measurementMetric(measurement, size, allowTolerance);
+		const res = measurementMetric(measurement, size, factors, allowTolerance);
 
 		expect(res).toBeGreaterThan(0);
 	});
@@ -41,8 +45,9 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns 0 when measurement is within range without tolerance', () => {
 		const measurement = 184;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 
-		const res = measurementMetric(measurement, size);
+		const res = measurementMetric(measurement, size, factors);
 
 		expect(res).toBe(0);
 	});
@@ -50,8 +55,9 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns negative number when measurement is below range without tolerance', () => {
 		const measurement = 170;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 
-		const res = measurementMetric(measurement, size);
+		const res = measurementMetric(measurement, size, factors);
 
 		expect(res).toBeGreaterThan(0);
 	});
@@ -59,10 +65,31 @@ describe('measurementMetric', () => {
 	test('measurementMetric returns positive number when measurement is above range without tolerance', () => {
 		const measurement = 190;
 		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 1 };
 
-		const res = measurementMetric(measurement, size);
+		const res = measurementMetric(measurement, size, factors);
 
 		expect(res).toBeGreaterThan(0);
+	});
+
+	test('measurementMetric returns correctly factored metric when too high', () => {
+		const measurement = 185;
+		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 10, tooLow: 1 };
+
+		const res = measurementMetric(measurement, size, factors);
+
+		expect(res).toEqual(10);
+	});
+
+	test('measurementMetric returns correctly factored metric when too low', () => {
+		const measurement = 179;
+		const size = { min: 180, max: 184 };
+		const factors = { tooHigh: 1, tooLow: 10 };
+
+		const res = measurementMetric(measurement, size, factors);
+
+		expect(res).toEqual(10);
 	});
 });
 

--- a/src/lib/clothing/clothingUtils.ts
+++ b/src/lib/clothing/clothingUtils.ts
@@ -38,6 +38,7 @@ function calculateMatchingClothingSizeForTable(
 			const measurement = measurements[importance.measurement];
 			const size = clothingSize[importance.measurement];
 			const allowTolerance = importance.allowTolerance;
+			const factors = importance.factors ?? {tooHigh: 1, tooLow: 1};
 
 			if (!measurement) {
 				// console.warn(
@@ -53,7 +54,8 @@ function calculateMatchingClothingSizeForTable(
 			return measurementMetric(
 				measurement,
 				size,
-				allowTolerance ? getMeasurementTolerance(table.name) : undefined
+				factors,
+				allowTolerance ? getMeasurementTolerance(table.name) : undefined,
 			);
 		});
 
@@ -69,17 +71,19 @@ function calculateMatchingClothingSizeForTable(
 export function measurementMetric(
 	measurement: number,
 	size: { min: number; max: number },
+	factors: { tooHigh: number; tooLow: number },
 	tolerance?: HumanMeasurementTolerance
 ): number {
 	const min = size.min * (1 - (tolerance?.down ?? 0));
 	const max = size.max * (1 + (tolerance?.up ?? 0));
 	if (min <= measurement && max >= measurement) return 0;
 
-	if (min > measurement) return Math.abs(measurement - min);
-	if (max < measurement) return Math.abs(max - measurement);
+	if (min > measurement) return Math.abs(measurement - min) * factors.tooLow;
+	if (max < measurement) return Math.abs(max - measurement) * factors.tooHigh;
 
 	throw new Error('This should never happen');
 }
+
 export function getMeasurementTolerance(name: ClothingName): HumanMeasurementTolerance {
 	switch (name) {
 		case 'DA_O':


### PR DESCRIPTION
Instead of assuming a metric of just how much it exceeds a given measurement range, it is not configurable to set a  factor for a "too high" measurement and a "too low" measurement. This makes it possible to set different weights for if a circumference measurement is exceeded or not. For example, having a jacket where the waist circumference is too small and doesn't fit around the wearers body  should result in a higher "difference metric" than if it is too large (it will still fit)